### PR TITLE
Options, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ by the CSS document to a folder. `options` may contain the following values:
    file. This function can simply ignore the error if desired, which causes the
    URL to be unchanged from the source file. The default function throws the
    error.
+ * `func`: The name of the CSS function that references an asset in the input.
+   Defaults to `'url'`. For example, if `func: 'asset'` is specified, all
+   `asset(...)` calls will be found in the input and the copied to the output.
+   The output CSS will always use `url(...)` to reference the copied assets in
+   the build output.
 
 The path to each asset source is determined by the `src` directory and the
 `position.source` property of each node that is set when parsing with

--- a/fixtures/test.css
+++ b/fixtures/test.css
@@ -1,3 +1,3 @@
 .test {
-    test: asset(test.txt);
+    test: url(test.txt);
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function assets(options) {
     options.src = path.resolve(options.src || '.');
     options.onError = options.onError || defaultError;
     options.prefix = options.prefix || '';
-    options.func = options.func || 'asset';
+    options.func = options.func || 'url';
 
     return function(style) {
         process(options, style);

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ var HASH = 'a94a8fe5ccb19ba6';
 test('copy asset files to directory', function(t) {
     rimraf.sync('build');
 
-    var result = rework('.test { test: asset(test.txt); }')
+    var result = rework('.test { test: url(test.txt); }')
         .use(assets({
             src: 'fixtures',
             dest: 'build'
@@ -34,7 +34,7 @@ test('copy asset files to directory', function(t) {
 test('use different outputUrl', function(t) {
     rimraf.sync('build');
 
-    var result = rework('.test { test: asset(test.txt); }')
+    var result = rework('.test { test: url(test.txt); }')
         .use(assets({
             src: 'fixtures',
             dest: 'build',
@@ -58,7 +58,7 @@ test('use different outputUrl', function(t) {
 test('copy assets from nested directory', function(t) {
     rimraf.sync('build');
 
-    var result = rework('.test { test: asset(fixtures/test.txt); }')
+    var result = rework('.test { test: url(fixtures/test.txt); }')
         .use(assets({ dest: 'build' }))
         .toString();
 
@@ -80,7 +80,7 @@ test('replace multiple url calls', function(t) {
 
     var src = [
         '.test {',
-        '  test: foo asset(test.txt), asset(test.txt) bar;',
+        '  test: foo url(test.txt), url(test.txt) bar;',
         '}'
     ].join('\n');
 
@@ -125,7 +125,7 @@ test('do not copy absolute URLs', function(t) {
 
     var src = [
         '.test {',
-        '  test: asset(http://example.com/test.txt);',
+        '  test: url(http://example.com/test.txt);',
         '}'
     ].join('\n');
 
@@ -143,7 +143,7 @@ test('do not copy data URLs', function(t) {
 
     var src = [
         '.test {',
-        '  test: asset(data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D);',
+        '  test: url(data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D);',
         '}'
     ].join('\n');
 
@@ -161,7 +161,7 @@ test('allow onError to ignore errors', function(t) {
 
     var src = [
         '.test {',
-        '  test: asset(missing.txt);',
+        '  test: url(missing.txt);',
         '}'
     ].join('\n');
 
@@ -180,12 +180,12 @@ test('allow onError to ignore errors', function(t) {
     t.end();
 });
 
-test('accept a custom function instead of asset()', function(t) {
+test('accept a custom function instead of url()', function(t) {
     rimraf.sync('build');
 
     var src = [
         '.test {',
-        '  test: url(test.txt);',
+        '  test: asset(test.txt);',
         '}'
     ].join('\n');
 
@@ -193,7 +193,7 @@ test('accept a custom function instead of asset()', function(t) {
         .use(assets({
             src: 'fixtures',
             dest: 'build',
-            func: 'url'
+            func: 'asset'
         }))
         .toString();
 


### PR DESCRIPTION
This is based off of #4 with some changes. Main change is that `func` now defaults to `'url'` (with added documentation for `func` option).
