### PR TITLE
If no valid path is found, return the original

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function assets(options) {
 
     function process(asset) {
         var u = url.parse(asset);
-        if (u.protocol) {
+        if (u.protocol || !u.pathname) {
             return original(asset);
         }
 


### PR DESCRIPTION
I have no clue why, but Leaflet's styles include `url(#default#VML)`. I don't know if this sort of thing is widespread, but it seems like a good idea to leave stuff we don't recognize alone.
